### PR TITLE
Restore default ZNear

### DIFF
--- a/code/Player/DeathmatchPlayer.cs
+++ b/code/Player/DeathmatchPlayer.cs
@@ -212,8 +212,6 @@
 
 	public override void PostCameraSetup( ref CameraSetup setup )
 	{
-		setup.ZNear = 0.1f;
-
 		if ( DeathmatchGame.CurrentState == DeathmatchGame.GameStates.GameEnd )
 			return;
 


### PR DESCRIPTION
This was a hack to fix peaking through walls with high fov. It causes a ton of zfighting starting from less than 1m away.
The proper solution would be lowering the max fov or slightly lowering the default znear, as this issue affects every gamemode, not just dm98.