### PR TITLE
Fix Shotgun Holdtype

### DIFF
--- a/code/Entities/Weapons/Shotgun.cs
+++ b/code/Entities/Weapons/Shotgun.cs
@@ -152,7 +152,7 @@ partial class Shotgun : DeathmatchWeapon
 
 	public override void SimulateAnimator( PawnAnimator anim )
 	{
-		anim.SetAnimParameter( "holdtype", 2 ); // TODO this is shit
+		anim.SetAnimParameter( "holdtype", 3 ); // TODO this is shit
 		anim.SetAnimParameter( "aim_body_weight", 1.0f );
 	}
 


### PR DESCRIPTION
Shotgun was using the wrong holdtype

before
![image](https://user-images.githubusercontent.com/39461072/173687861-54d19916-f96e-463f-8ae6-b2cada8a0ec0.png)


after
![image](https://user-images.githubusercontent.com/39461072/173687821-f2834100-adba-4688-8d68-02d698766baa.png)