### PR TITLE
Fix charging station health clamp not working

### DIFF
--- a/code/Entities/ChargerStation.cs
+++ b/code/Entities/ChargerStation.cs
@@ -106,14 +106,14 @@ partial class ChargerStation : KeyframeEntity, IUse
 		if ( IsArmourCharger )
 		{
 			player.Armour += add;
-			player.Armour.Clamp( 0, 100 );
+			player.Armour = player.Armour.Clamp( 0, 100 );
 			return player.Armour < 100;
 		}
 
 		if ( !IsArmourCharger )
 		{
 			player.Health += add;
-			player.Health.Clamp( 0, 100 );
+			player.Health = player.Health.Clamp( 0, 100 );
 			return player.Health < 100;
 		}
 


### PR DESCRIPTION
There was a clamp being ran on the players health when using the charging station, yet it wasn't returned to anything, leaving the player to have sometimes just over 100 health.